### PR TITLE
use ng-src to avoid image request when angular is not loaded

### DIFF
--- a/partials/related-results.html
+++ b/partials/related-results.html
@@ -2,7 +2,7 @@
 	<div class="rel-heading"><span class="rel-span">Related Results</span></div>
 	<ul class="related-results list-group">
 		<li class="list-group-item" ng-repeat="movie in related.Search">
-			<img class="rel-thumnails" src="{{ movie.Poster=='N/A' ? 'http://placehold.it/35x35&text=N/A' : movie.Poster }}">
+			<img class="rel-thumnails" ng-src="{{ movie.Poster=='N/A' ? 'http://placehold.it/35x35&text=N/A' : movie.Poster }}">
 			<a class="rel-title" href="#" id="{{ $index + 1 }}" ng-click="update(movie)">{{ movie.Title }}</a><span class="rel-year">, {{ movie.Year }}</span>
 		</li>
 	</ul>


### PR DESCRIPTION
Hi,

Cool project. I noticed to get the 404 first opening the app. It was due to browser loading the literal src link which actually was a angular expression. The problem was mitigated when angular's templating kicked in but why not to fix it?
